### PR TITLE
suppress faraday logging by default

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -29,7 +29,7 @@ module Presto::Client
 
       faraday = Faraday.new(url: "http://#{server}") do |faraday|
         #faraday.request :url_encoded
-        faraday.response :logger
+        faraday.response :logger if options[:http_debug]
         faraday.adapter Faraday.default_adapter
       end
 


### PR DESCRIPTION
also add `http_debug` option to display faraday's log.
