### PR TITLE
Allow Faraday 0.9 to satisfy dependency.

### DIFF
--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.1"
 
-  gem.add_dependency "faraday", ["~> 0.8.8"]
+  gem.add_dependency "faraday", [">= 0.8.8", "< 0.10.0"]
   gem.add_dependency "multi_json", ["~> 1.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2"]


### PR DESCRIPTION
There's no difference between using Faraday 0.8 and Faraday 0.9 for this project. Both work correctly as far as I can see.

I needed to loosen the Gemspec requirements to be able to include the gem into a number of projects - so here's a PR that loosens it to be either 0.8 or 0.9.
