### PR TITLE
Bump faraday version from 0.12 to 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org/'
 gemspec
 
 group :development, :test do
-  gem 'tiny-presto', '~> 0.0.7'
-  gem 'presto-client'
+  gem 'tiny-presto', "~> 0.0.8"
 end

--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -196,7 +196,7 @@ module Trino::Client
       begin
         begin
           response = @faraday.get(uri)
-        rescue Faraday::Error::TimeoutError, Faraday::Error::ConnectionFailed
+        rescue Faraday::TimeoutError, Faraday::ConnectionFailed
           # temporally error to retry
           response = nil
         rescue => e

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.1"
 
-  gem.add_dependency "faraday", ["~> 0.12"]
-  gem.add_dependency "faraday_middleware", ["~> 0.12.2"]
+  gem.add_dependency "faraday", ["~> 1.0"]
+  gem.add_dependency "faraday_middleware", ["~> 1.0"]
     gem.add_dependency "msgpack", [">= 0.7.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]
-  gem.add_development_dependency "webmock", ["~> 2.0.0"]
+  gem.add_development_dependency "webmock", ["~> 3.0"]
   gem.add_development_dependency "addressable", ["~> 2.4.0"] # 2.5.0 doesn't support Ruby 1.9.3
   gem.add_development_dependency "simplecov", ["~> 0.10.0"]
 end


### PR DESCRIPTION
# Purpose

resolves: https://github.com/treasure-data/trino-client-ruby/issues/65

Currently the gem trino-client depends on Faraday 0.12. If a project uses the lastest version of Faraday (1.7) and introduces trino-client, it needs to have the Faraday gem downgraded. 

# Overview

- Bump Faraday version
- Bump Webmock version to 3.0
- Bump tiny-presto version

# Checklist

- [x] Code compiles correctly
- [x] ~Created tests which fail without the change (if possible)~
- [x] All tests passing
- [x] ~Extended the README / documentation, if necessary~