### PR TITLE
Model version setting option and Faraday deprecation fixes

### DIFF
--- a/lib/trino/client/faraday_client.rb
+++ b/lib/trino/client/faraday_client.rb
@@ -123,7 +123,7 @@ module Trino::Client
 
   def self.optional_headers(options)
     usePrestoHeader = false
-    if v = options[:model_version] && v < 351
+    if options[:model_version] && options[:model_version] < 351
       usePrestoHeader = true
     end
 

--- a/lib/trino/client/faraday_client.rb
+++ b/lib/trino/client/faraday_client.rb
@@ -75,7 +75,7 @@ module Trino::Client
 
     faraday = Faraday.new(faraday_options) do |faraday|
       if options[:user] && options[:password]
-        faraday.basic_auth(options[:user], options[:password])
+        faraday.request(:basic_auth, options[:user], options[:password])
       end
       if options[:follow_redirect]
         faraday.use FaradayMiddleware::FollowRedirects

--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -34,7 +34,7 @@ module Trino::Client
       @state = :running
       @retry_timeout = options[:retry_timeout] || 120
       if model_version = @options[:model_version]
-        @models = ModelVersions.const_get("V#{model_version.gsub(".", "_")}")
+        @models = ModelVersions.const_get("V#{model_version.to_s.gsub(".", "_")}")
       else
         @models = Models
       end

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.has_rdoc = false
 
   gem.required_ruby_version = ">= 1.9.1"
 


### PR DESCRIPTION
# Purpose

When using the current release (1.0.1), I've encountered some problems which this PR fixes:
1. `model_version` setting was not properly treated in `faraday_client` helper method due to operator priority (`&&` operator has higher priority than assignment operator)
2. `model_version` check expects numeric values, but module load treated the value as a string (by using `gsub` method)
3. Faraday has changed how basic auth should be setup and was printing a deprecation warning
4. gemspec used deprecated `has_rdoc` setting

Faraday deprecation message:
> WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0. While initializing your connection, use `#request(:basic_auth, ...)` instead. See https://lostisland.github.io/faraday/middleware/authentication for more usage info.

Gemspec deprecation message:
> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01. Gem::Specification#has_rdoc= called from trino-client-ruby/trino-client.gemspec:18.

# Overview

- Fix `model_version` setting
- Fix `faraday` deprecation
- Fix gemspec deprecation

# Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary