### PR TITLE
Upgrade minimum ruby version to 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 1.9.1"
+  gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "faraday", ["~> 1.0"]
   gem.add_dependency "faraday_middleware", ["~> 1.0"]


### PR DESCRIPTION
# Purpose
- Maintenance
- Preparation for upgrading to ruby 3.0

# Overview

- As of Jan 2023, the minimum maintained ruby version is 2.7. ruby 2.6 is deprecated now.
   https://endoflife.date/ruby

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary