### PR TITLE
Introduce release-drafter github action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,45 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '👋 Deprecated'
+    labels:
+      - 'deprecation'
+  - title: '⛓  Dependency Updates'
+    label:
+      - 'library-update'
+      - 'test-library-update'
+      - 'dependencies'
+  - title: '🛠  Internal Updates'
+    label:
+      - 'internal'
+      - 'kaizen'
+      - 'chore'
+  - title: '📚 Docs'
+    labels:
+      - 'doc'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+
+template: |
+  ## What's Changed
+  $CHANGES
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+autolabeler:
+  - label: 'doc'
+    files:
+      - '*.md'
+      - '*.yml'
+      - '*.yaml'
+  - label: 'bug'
+    title:
+      - '/fix/i'
+  - label: 'deprecation'
+    title:
+      - '/deprecate/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,29 @@
+---
+name: Release Drafter
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+    # pull_request_target event is required for auto-labeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Overview

- Introduce release-drafter github action to generate release note automatically when tagging a commit.
- The ci failure, `Release Drafter / update_release_draft (pull_request) `, continue to fail until this pull request is merge into master. Please ignore.

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary