### PR TITLE
Fix for Ruby 3.2.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.7', '3.0', '3.2']
-
+    timeout-minutes: 5 # Typically ends within 1-2 min
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['2.7', '3.0', '3.2']
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.2']
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/trino/client/faraday_client.rb
+++ b/lib/trino/client/faraday_client.rb
@@ -70,7 +70,8 @@ module Trino::Client
     url = "#{ssl ? "https" : "http"}://#{server}"
     proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
 
-    faraday_options = {url: url, proxy: "#{proxy}"}
+    faraday_options = {url: url}
+    faraday_options[:proxy] = "#{proxy}" if proxy
     faraday_options[:ssl] = ssl if ssl
 
     faraday = Faraday.new(faraday_options) do |faraday|

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "addressable", "~> 2.8.1" # 2.5.0 doesn't support Ruby 1.9.3
   gem.add_development_dependency "simplecov", "~> 0.22.0"
   gem.add_development_dependency "standard", "~> 1.24.3"
+  gem.add_development_dependency "psych", "~> 3"
 end


### PR DESCRIPTION
# Purpose

Closes #93 

# Overview

- Added Ruby 3.2 job to CI
- Added Psych 3 to workaround with Ruby 3.2's changes in YAML handling
- Disable fail-fast so we can check which Ruby version fail
- Added workaround for https://github.com/lostisland/faraday/issues/1492


Describe the list of work you have done in this pull request.



Example:
- Add something
- Remove other things

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary