### PR TITLE
Faraday 2.x and 1.x cross support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,6 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.7', '3.0', '3.2']
+        faraday-version: ['~> 1', '~> 2']
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday-version }}
     timeout-minutes: 5 # Typically ends within 1-2 min
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec
 
 group :development, :test do
   gem "tiny-presto", "~> 0.0.10"
+  gem "faraday", ENV.fetch("FARADAY_VERSION", "~> 2")
 end

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -16,6 +16,8 @@
 module Trino::Client
 
   require 'faraday'
+  require 'faraday/gzip'
+  require 'faraday/follow_redirects'
   require 'trino/client/models'
   require 'trino/client/errors'
   require 'trino/client/faraday_client'

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -16,7 +16,6 @@
 module Trino::Client
 
   require 'faraday'
-  require 'faraday_middleware'
   require 'trino/client/models'
   require 'trino/client/errors'
   require 'trino/client/faraday_client'

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "faraday", ">= 1", "< 3"
-  gem.add_dependency "faraday_middleware", ["~> 1.0"]
   gem.add_dependency "msgpack", [">= 1.5.1"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 14.0"]

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "faraday", ">= 1", "< 3"
+  gem.add_dependency "faraday-gzip", ">= 1"
+  gem.add_dependency "faraday-follow_redirects", ">= 0.3"
   gem.add_dependency "msgpack", [">= 1.5.1"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 14.0"]


### PR DESCRIPTION
# Purpose

Added Faraday 2.x support while keeping Faraday 1.x support.

# Overview

- Middleware usage is rewritten in a way compatible with both Faraday 1.x and 2.x.
- Added Faraday version to CI matrix.

## Note

You can see that Faraday `2.7.4` and `1.10.3` are used in each CI jobs.

https://github.com/treasure-data/trino-client-ruby/actions/runs/4239442131/jobs/7367502926
<img width="343" alt="image" src="https://user-images.githubusercontent.com/127635/220523489-0877e257-d1bd-4cdf-8e6a-767b224b3f44.png">

https://github.com/treasure-data/trino-client-ruby/actions/runs/4239441863/jobs/7367502185
<img width="350" alt="image" src="https://user-images.githubusercontent.com/127635/220523553-d21e5435-873b-4a41-afcc-c112c55846fe.png">


# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary