### PR TITLE
CI: Do not trigger "push" event on pull requests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,12 @@
 
 name: Ruby
 
-on: [push, pull_request]
+on:
+  push:
+    branch:
+      - main
+      - master
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
# Purpose

To make CI faster.

# Overview

On pull requests, GitHub Actions are executed both on `push` and `pull_request` event at this moment.
This is redundant because same CI job is executed twice.
See https://github.com/treasure-data/trino-client-ruby/pull/94 as example

After this PR, `push` event is triggered only when `main` and `master` branch (when PR is merged).

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary