### PR TITLE
linter: Enable linter on lib 

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,32 @@
 ---
 ignore:
-  - 'lib/trino/client/*.rb'
+  - 'lib/trino/client/*.rb':
+      - Layout/EmptyLinesAroundModuleBody
+      - Layout/FirstHashElementIndentation
+      - Layout/SpaceAroundEqualsInParameterDefault
+      - Layout/SpaceInsideBlockBraces
+      - Layout/SpaceInsideBlockBraces
+      - Lint/AssignmentInCondition
+      - Lint/UselessAssignment
+      - Naming/VariableName
+      - Performance/RegexpMatch
+      - Performance/StringReplacement
+      - Style/ConditionalAssignment
+      - Style/HashConversion
+      - Style/HashSyntax
+      - Style/NilComparison
+      - Style/RedundantBegin
+      - Style/RedundantFileExtensionInRequire
+      - Style/RedundantInterpolation
+      - Style/RedundantReturn
+      - Style/RedundantSelf
+      - Style/SafeNavigation
+      - Style/Semicolon
+      - Style/StringLiterals
+      - Style/StringLiteralsInInterpolation
+      - Style/TernaryParentheses
+      - Style/TrailingCommaInHashLiteral
+
   - 'modelgen/model_versions.rb': &modelgen_common
       - Style/StringLiterals # TODO: Remove this later
       - Layout/DotPosition # TODO: Remove this later

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,6 @@
 ---
 ignore:
-  - 'lib/**/*.rb':
+  - 'lib/trino/client/*.rb':
       - Layout/EmptyLinesAroundModuleBody
       - Layout/FirstHashElementIndentation
       - Layout/SpaceAroundEqualsInParameterDefault

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,6 @@
 ---
 ignore:
-  - 'lib/trino/client/*.rb':
+ - 'lib/trino/client/*.rb':
       - Layout/EmptyLinesAroundModuleBody
       - Layout/FirstHashElementIndentation
       - Layout/SpaceAroundEqualsInParameterDefault

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,6 @@
 ---
 ignore:
-  - 'lib/trino/client/*.rb':
+  - 'lib/**/*.rb':
       - Layout/EmptyLinesAroundModuleBody
       - Layout/FirstHashElementIndentation
       - Layout/SpaceAroundEqualsInParameterDefault

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,6 @@
 ---
 ignore:
- - 'lib/trino/client/*.rb':
+  - 'lib/trino/client/*.rb':
       - Layout/EmptyLinesAroundModuleBody
       - Layout/FirstHashElementIndentation
       - Layout/SpaceAroundEqualsInParameterDefault

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -107,11 +107,12 @@ module Trino::Client
         raise TrinoError, "Query #{@api.current_results.id} has no columns"
       end
 
-      begin
+      loop do
         if data = @api.current_results.data
           block.call(data)
         end
-      end while advance_and_raise
+        break unless advance_and_raise
+      end
     end
 
     def query_info

--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -193,7 +193,7 @@ module Trino::Client
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       attempts = 0
 
-      begin
+      loop do
         begin
           response = @faraday.get(uri)
         rescue Faraday::TimeoutError, Faraday::ConnectionFailed
@@ -218,7 +218,9 @@ module Trino::Client
 
         attempts += 1
         sleep attempts * 0.1
-      end while (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) < @retry_timeout && !client_aborted?
+
+        break unless (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) < @retry_timeout && !client_aborted?
+      end
 
       exception! TrinoHttpError.new(408, "Trino API error due to timeout")
     end


### PR DESCRIPTION
# Purpose

To improve the code quality of actual library sources.

# Overview

- Enabled standardb on `lib` sources but suppressed most of conventional-level checks. Will improve eventually.
- Fixed one warning-level chekc [Lint/Loop](https://docs.rubocop.org/rubocop/cops_lint.html#lintloop)

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary