### PR TITLE
Upgrade minimum ruby version to 2.7 in trino-client-ruby.gemspec

### DIFF
--- a/trino-client-ruby/trino-client-ruby.gemspec
+++ b/trino-client-ruby/trino-client-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files         = ["lib/trino-client-ruby.rb"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 1.9.1"
+  gem.required_ruby_version = ">= 2.7.0"
 
   gem.add_dependency "trino-client", Trino::Client::VERSION
 end


### PR DESCRIPTION
# Purpose
Same as #86 

# Overview
Same as #86 

- As of Feb 2023, the minimum maintained ruby version is 2.7. ruby 2.6 is deprecated now.
   https://endoflife.date/ruby

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary