### PR TITLE
Reduce published gem size

### DIFF
--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/treasure-data/trino-client-ruby"
   gem.license       = "Apache-2.0"
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[.git .standard modelgen spec trino-client-ruby Gemfile Rakefile publish.rb release.rb]) }
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
# Purpose

This Pull Request reduces the published gem size by excluding unneeded files for execution.
The latest version's gem size is **98.5 KB**.

<img width="251" alt="image" src="https://github.com/treasure-data/trino-client-ruby/assets/473530/a7ae669f-7e34-40f8-8701-91d5d084c6cc">

https://rubygems.org/gems/trino-client/versions/2.0.0

# Overview

The PR updates the `files` option in the gemspec file.

You can confirm the size diff by the following verification: 100K -> 84K (**-16K**)

```console
$ git checkout master && gem build -o before.gem
...
$ git checkout reduce-published-gem-size && gem build -o after.gem
...
$ du -h before.gem after.gem
100K	before.gem
 84K	after.gem
```

---

Here are files included in the packed gem file:

```console
$ gem build && gem unpack *.gem
...
$ tree trino-client-2.0.0/
trino-client-2.0.0//
├── ChangeLog.md
├── LICENSE
├── README.md
├── SECURITY.md
├── lib/
│   ├── trino/
│   │   ├── client/
│   │   │   ├── client.rb
│   │   │   ├── errors.rb
│   │   │   ├── faraday_client.rb
│   │   │   ├── model_versions/
│   │   │   │   ├── 0.149.rb
│   │   │   │   ├── 0.153.rb
│   │   │   │   ├── 0.173.rb
│   │   │   │   ├── 0.178.rb
│   │   │   │   ├── 0.205.rb
│   │   │   │   ├── 303.rb
│   │   │   │   ├── 316.rb
│   │   │   │   └── 351.rb
│   │   │   ├── models.rb
│   │   │   ├── query.rb
│   │   │   ├── statement_client.rb
│   │   │   └── version.rb
│   │   └── client.rb
│   └── trino-client.rb
└── trino-client.gemspec

5 directories, 22 files
```

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
