### PR TITLE
Add utility for transforming Trino ROW type columns into Ruby hashes

### DIFF
--- a/lib/trino/client/column_value_parser.rb
+++ b/lib/trino/client/column_value_parser.rb
@@ -1,0 +1,118 @@
+module Trino::Client
+  class ColumnValueParser
+    INSIDE_MATCHING_PARENS_REGEX = /\((?>[^)(]+|\g<0>)*\)/
+
+    attr_reader :name, :type
+
+    def initialize(column)
+      @name = column.name
+      @type = prepare_type_for_parsing(column.type)
+    end
+
+    # Public: Parse the value of a row's field by using its column's Trino type.
+    # Trino types can be scalars like VARCHAR and TIMESTAMP or complex types
+    # like ARRAY and ROW. ROW types are treated as objects.
+    # An ARRAY column's type is an array of types as you'd expect. A ROW
+    # column's type is a comma-separated list of space-separated (name, type) tuples.
+    #
+    # data - The value of a row's field. Can be a string, number, an array of those,
+    #        or an arrays of arrays, etc.
+    # dtype - The Trino type string of the column. See above explanation.
+    #
+    # Returns:
+    # - The given value for strings and numbers
+    # - A Time for timestamps
+    # - A Hash of { field1 => value1, field2 => value2, ...etc } for row types
+    # - An array of the above for array types
+    def value(data, dtype = type)
+      # Convert Trino ARRAY elements into Ruby Arrays
+      if starts_with?(dtype, 'array(')
+        return parse_array_element(data, dtype)
+
+      # Convert Trino ROW elements into Ruby Hashes
+      elsif starts_with?(dtype, 'row(')
+        return parse_row_element(data, dtype)
+
+      # Decode VARBINARY strings
+      elsif starts_with?(dtype, 'varbinary')
+        return blank?(data) ? nil : Base64.decode64(data)
+
+      # Convert TIMESTAMP fields to Ruby Time objects
+      elsif starts_with?(dtype, 'timestamp')
+        return blank?(data) ? nil : Time.parse(data)
+      end
+
+      # Other types are returned unaltered
+      data
+    end
+
+    private
+
+    # Private: Remove quotation marks and handle recent versions of
+    # Trino having a 'with time zone' suffix on some fields that breaks
+    # out assumption that types don't have spaces in them.
+    #
+    # Returns a string.
+    def prepare_type_for_parsing(type)
+      type.gsub('"', '').gsub(' with time zone', '_with_time_zone')
+    end
+
+    def parse_array_element(data, dtype)
+      # If the element is empty, return an empty array
+      return [] if blank?(data)
+
+      # Inner data type will be the current dtype with `array(` and `)` chopped off
+      inner_dtype = dtype.match(INSIDE_MATCHING_PARENS_REGEX)[0][1..-2]
+
+      data.map { |inner_data| value(inner_data, inner_dtype) }
+    end
+
+    def parse_row_element(data, dtype)
+      # If the element is empty, return an empty object
+      return {} if blank?(data)
+
+      parsed_row_element = {}
+
+      inner_dtype = dtype.match(INSIDE_MATCHING_PARENS_REGEX)[0][1..-2]
+      elems = inner_dtype.split(' ')
+      num_elems_to_skip = 0
+      field_position = 0
+
+      # Iterate over each datatype of the row and mutate parsed_row_element
+      # to have a key of the field name and value for that field's value.
+      elems.each_with_index do |field, i|
+        # We detected an array or row and are skipping all of the elements within it
+        # since its conversion was handled by calling `value` recursively.
+        if num_elems_to_skip.positive?
+          num_elems_to_skip -= 1
+          next
+        end
+
+        # Field names never have these characters and are never the last element.
+        next if field.include?(',') || field.include?('(') || field.include?(')') || i == elems.length - 1
+
+        type = elems[(i + 1)..].join(' ')
+
+        # If this row has a nested array or row, the type of this field is that array or row's type.
+        if starts_with?(type, 'array(') || starts_with?(type, 'row(')
+          datatype = type.sub(/\(.*/, '')
+          type = "#{datatype}#{type.match(INSIDE_MATCHING_PARENS_REGEX)[0]}"
+          num_elems_to_skip = type.split(' ').length # see above comment about num_elems_to_skip
+        end
+
+        parsed_row_element[field] = value(data[field_position], type)
+        field_position += 1
+      end
+
+      parsed_row_element
+    end
+
+    def blank?(obj)
+      obj.respond_to?(:empty?) ? !!obj.empty? : !obj
+    end
+
+    def starts_with?(str, prefix)
+      prefix.respond_to?(:to_str) && str[0, prefix.length] == prefix
+    end
+  end
+end

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -18,6 +18,7 @@ module Trino::Client
   require 'faraday'
   require 'faraday/gzip'
   require 'faraday/follow_redirects'
+  require 'trino/client/column_value_parser'
   require 'trino/client/models'
   require 'trino/client/errors'
   require 'trino/client/faraday_client'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -8,15 +8,17 @@ describe Trino::Client::Client do
       [
         Models::Column.new(name: 'animal', type: 'string'),
         Models::Column.new(name: 'score', type: 'integer'),
-        Models::Column.new(name: 'name', type: 'string')
+        Models::Column.new(name: 'name', type: 'string'),
+        Models::Column.new(name: 'foods', type: 'array(string string)'),
+        Models::Column.new(name: 'traits', type: 'row(breed string, num_spots integer)')
       ]
     end
 
     it 'multiple rows' do
       rows = [
-        ['dog', 1, 'Lassie'],
-        ['horse', 5, 'Mr. Ed'],
-        ['t-rex', 37, 'Doug']
+        ['dog', 1, 'Lassie', ['kibble', 'peanut butter'], ['spaniel', 2]],
+        ['horse', 5, 'Mr. Ed', ['hay', 'sugar cubes'], ['some horse', 0]],
+        ['t-rex', 37, 'Doug', ['rodents', 'small dinos'], ['dino', 0]]
       ]
       client.stub(:run).and_return([columns, rows])
 
@@ -27,18 +29,26 @@ describe Trino::Client::Client do
       expect(rehashed[0]['animal']).to eq 'dog'
       expect(rehashed[0]['score']).to eq 1
       expect(rehashed[0]['name']).to eq 'Lassie'
+      expect(rehashed[0]['foods']).to eq ['kibble', 'peanut butter']
+      expect(rehashed[0]['traits']).to eq ['spaniel', 2]
 
       expect(rehashed[0].values[0]).to eq 'dog'
       expect(rehashed[0].values[1]).to eq 1
       expect(rehashed[0].values[2]).to eq 'Lassie'
+      expect(rehashed[0].values[3]).to eq ['kibble', 'peanut butter']
+      expect(rehashed[0].values[4]).to eq ['spaniel', 2]
 
       expect(rehashed[1]['animal']).to eq 'horse'
       expect(rehashed[1]['score']).to eq 5
       expect(rehashed[1]['name']).to eq 'Mr. Ed'
+      expect(rehashed[1]['foods']).to eq ['hay', 'sugar cubes']
+      expect(rehashed[1]['traits']).to eq ['some horse', 0]
 
       expect(rehashed[1].values[0]).to eq 'horse'
       expect(rehashed[1].values[1]).to eq 5
       expect(rehashed[1].values[2]).to eq 'Mr. Ed'
+      expect(rehashed[1].values[3]).to eq ['hay', 'sugar cubes']
+      expect(rehashed[1].values[4]).to eq ['some horse', 0]
     end
 
     it 'empty results' do
@@ -58,17 +68,21 @@ describe Trino::Client::Client do
         "animal" => "wrong",
         "score" => "count",
         "name" => nil,
+        "foods" => nil,
+        "traits" => nil
       }]
     end
 
     it 'handles too many result columns' do
-      rows = [['wrong', 'count', 'too', 'much', 'columns']]
+      rows = [['wrong', 'count', 'too', 'too', 'too', 'much', 'columns']]
       client.stub(:run).and_return([columns, rows])
 
       expect(client.run_with_names('fake query')).to eq [{
         "animal" => "wrong",
         "score" => "count",
-        "name" => 'too',
+        "name" => "too",
+        "foods" => "too",
+        "traits" => "too"
       }]
     end
   end

--- a/spec/column_value_parser_spec.rb
+++ b/spec/column_value_parser_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe Trino::Client::ColumnValueParser do
+  def column_value(data, type)
+    column = Struct.new(:type, :name).new(type)
+    Trino::Client::ColumnValueParser.new(column).value(data)
+  end
+
+  it 'parses varchar values' do
+    data = 'a string'
+    type = 'varchar'
+    expected_value = 'a string'
+    expect(column_value(data, type)).to eq(expected_value)
+  end
+
+  it 'parses timestamp values' do
+    data = '2022-07-01T14:53:02Z'
+    type = 'timestamp with time zone'
+    expected_value = Time.parse(data)
+    expect(column_value(data, type)).to eq(expected_value)
+  end
+
+  it 'parses array type values' do
+    data = [1, 2, 3, 4]
+    type = 'array(integer, integer, integer, integer)'
+    expected_value = [1, 2, 3, 4]
+    expect(column_value(data, type)).to eq(expected_value)
+  end
+
+  it 'parses row type values' do
+    data = [
+      'userId',
+      'userLogin',
+      'SKU_FREE',
+      'TYPE_USER',
+      '2022-07-01T14:53:02Z',
+      ''
+    ]
+    type = 'row(id varchar, "name" varchar, plan_sku varchar, type varchar, created_at timestamp with time zone, organization_tenant_name varchar)'
+    expected_value = {
+      'id' => 'userId',
+      'name' => 'userLogin',
+      'plan_sku' => 'SKU_FREE',
+      'type' => 'TYPE_USER',
+      'created_at' => Time.parse('2022-07-01T14:53:02Z'),
+      'organization_tenant_name' => ''
+    }
+    value = column_value(data, type)
+    expect(column_value(data, type)).to eq(expected_value)
+    expect(value['created_at'].is_a?(Time)).to eq true
+  end
+
+  it 'parses an array of row type values' do
+    data = [[
+      'userId',
+      'userLogin',
+      'SKU_FREE',
+      'TYPE_USER',
+      '2022-07-01T14:53:02Z',
+      ''
+    ]]
+    type = 'array(row(id varchar, "name" varchar, plan_sku varchar, type varchar, created_at timestamp with time zone, organization_tenant_name varchar))'
+    expected_value = [{
+      'id' => 'userId',
+      'name' => 'userLogin',
+      'plan_sku' => 'SKU_FREE',
+      'type' => 'TYPE_USER',
+      'created_at' => Time.parse('2022-07-01T14:53:02Z'),
+      'organization_tenant_name' => ''
+    }]
+    value = column_value(data, type)
+    expect(column_value(data, type)).to eq(expected_value)
+    expect(value[0]['created_at'].is_a?(Time)).to eq true
+  end
+
+  it 'parses row type values that have an array in them' do
+    data = [
+      'userId',
+      %w[userLogin1 userLogin2],
+      'value'
+    ]
+    type = 'row(id varchar, logins array(varchar), onemore varchar)'
+    expected_value = {
+      'id' => 'userId',
+      'logins' => %w[userLogin1 userLogin2],
+      'onemore' => 'value'
+    }
+    expect(column_value(data, type)).to eq(expected_value)
+  end
+
+  it 'parses row type values that have a row in them' do
+    data = [
+      'userId',
+      ['userLogin', '2022-07-01T14:53:02Z', 1234],
+      'value'
+    ]
+    type = 'row(id varchar, subobj row(login varchar, created_at timestamp with time zone, id integer), onemore varchar)'
+    expected_value = {
+      'id' => 'userId',
+      'subobj' => {
+        'login' => 'userLogin',
+        'created_at' => Time.parse('2022-07-01T14:53:02Z'),
+        'id' => 1234
+      },
+      'onemore' => 'value'
+    }
+    value = column_value(data, type)
+    expect(column_value(data, type)).to eq(expected_value)
+    expect(value['subobj']['created_at'].is_a?(Time)).to eq true
+  end
+
+  it 'parses row type values that have nested rows in them' do
+    data = [
+      'userId',
+      ['userLogin', '2022-07-01T14:53:02Z', [1234]],
+      'value'
+    ]
+    type = 'row(id varchar, subobj row(login varchar, created_at timestamp with time zone, id row(subid integer)), onemore varchar)'
+    expected_value = {
+      'id' => 'userId',
+      'subobj' => {
+        'login' => 'userLogin',
+        'created_at' => Time.parse('2022-07-01T14:53:02Z'),
+        'id' => { 'subid' => 1234 }
+      },
+      'onemore' => 'value'
+    }
+    value = column_value(data, type)
+    expect(column_value(data, type)).to eq(expected_value)
+    expect(value['subobj']['created_at'].is_a?(Time)).to eq true
+  end
+end

--- a/spec/column_value_parser_spec.rb
+++ b/spec/column_value_parser_spec.rb
@@ -121,7 +121,7 @@ describe Trino::Client::ColumnValueParser do
       'subobj' => {
         'login' => 'userLogin',
         'created_at' => Time.parse('2022-07-01T14:53:02Z'),
-        'id' => { 'subid' => 1234 }
+        'id' => {'subid' => 1234}
       },
       'onemore' => 'value'
     }


### PR DESCRIPTION
Hello! I'm a longtime user of this gem, thanks so much for creating and maintaining it ✨ 

# Purpose

My team uses Ruby to parse a lot of data with Trino and many of the columns of the tables we handle are Trino ROW types (e.g. objects like a User). I'd like to upstream the code we've been using to parse these into Ruby hashes; we find it to be quite useful.

# Overview

## What's in here

Mostly I've added a new class, `Trino::Client::ColumnValueParser`, that parses the Trino type of a column in order to correctly transform the array that Trino returns for a ROW type into a Ruby hash. It handles ROW types that have ROW types (and ARRAY types too for what it's worth) embedded within them, as this is something we need.

We also exclusively stream results with something like

```ruby
client.query("select * ...") { |q| ... }
```

so I've added methods to `Trino::Client::Query` to accommodate transforming results like this:

```ruby
client.query("select * ...") do |q|
  q.each_row do |row|
    transformed_row = q.transform_row(row)
  end
end
```

It seemed like the best tests to modify were the ones in `client_spec.rb`. I updated an existing test to show that `run_with_names` returns arrays and then added a new spec that transforms the ROW types into hashes uses a helper method I added for folks who don't have access to the `query` object, like those using `run_with_names`.

## What's not in here

Within my team's work, having ROW types returned as arrays of elements, as Trino does by default, isn't as useful as having them transformed into Hashes like this PR enables. Therefore, I wonder if modifying `Trino::Client#run_with_names` to do this makes sense. However, this is a breaking change, so I didn't put it in here. What do you think? If you'd like, I could do that change in a subsequent PR. We don't use `run_with_names` so I don't have an opinion here. I also considered adding a new method that is a `run_with_names` clone but with this change, but figured I'd ask what you think would be useful before doing so.

Finally, I haven't updated the README at all. I'd be happy to! But I wanted to see if you think this is useful enough for folks to add it there.

Cheers, thanks for reading ✨
-- @kmcq

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
  - I think they will, but I didn't have success running them all locally
- [ ] Extended the README / documentation, if necessary