### PR TITLE
Add transform_row and scalar_parser documentation and make them easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ query = client.query("select * from sys.node")
 query_id = query.query_info.query_id
 query.each_row {|row| ... }  # when a thread is processing the query,
 client.kill(query_id)  # another thread / process can kill the query.
+
+# Use Query#transform_row to parse Trino ROW types into Ruby Hashes.
+# You can also set a scalar_parser to parse scalars how you'd like them.
+scalar_parser = -> (data, type) { (type === 'json') ? JSON.parse(data) : data }
+client.query("select * from sys.node") do |q|
+  q.scalar_parser = scalar_parser
+
+  # get query results. it feeds more rows until
+  # query execution finishes:
+  q.each_row {|row|
+    p q.transform_row(row)
+  }
+end
 ```
 
 ## Build models

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -58,6 +58,8 @@ module Trino::Client
       row_object
     end
 
+    attr_accessor :scalar_parser
+
     def initialize(api)
       @api = api
     end
@@ -102,12 +104,12 @@ module Trino::Client
 
     def column_value_parsers
       @column_value_parsers ||= columns.map {|column|
-        ColumnValueParser.new(column)
+        ColumnValueParser.new(column, scalar_parser)
       }
     end
 
     def transform_rows
-      rows.map(&:transform_row)
+      rows.map { |row| transform_row(row) }
     end
 
     def transform_row(row)

--- a/lib/trino/client/query.rb
+++ b/lib/trino/client/query.rb
@@ -103,7 +103,8 @@ module Trino::Client
     end
 
     def column_value_parsers
-      @column_value_parsers ||= columns.map {|column|
+      @column_value_parsers ||= {}
+      @column_value_parsers[scalar_parser] ||= columns.map {|column|
         ColumnValueParser.new(column, scalar_parser)
       }
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -90,6 +90,33 @@ describe Trino::Client::Client do
           "num_spots" => 2,
         },
       })
+
+      # And to show that you can change the scalar_parser, now we only add 1 to each integer.
+      query.scalar_parser = ->(data, type) { (type == 'integer') ? data + 1 : data }
+
+      transformed_rows = query.transform_rows
+
+      expect(transformed_rows[0]).to eq({
+        "animal" => "dog",
+        "score" => 2,
+        "name" => "Lassie",
+        "foods" => ["kibble", "peanut butter"],
+        "traits" => {
+          "breed" => "spaniel",
+          "num_spots" => 3,
+        },
+      })
+
+      expect(transformed_rows[1]).to eq({
+        "animal" => "horse",
+        "score" => 6,
+        "name" => "Mr. Ed",
+        "foods" => ["hay", "sugar cubes"],
+        "traits" => {
+          "breed" => "some horse",
+          "num_spots" => 1,
+        },
+      })
     end
 
     it 'empty results' do


### PR DESCRIPTION
# Purpose

As a follow up to #117, we wanted to document the new capabilities in the README and to make it a bit easier to use the new `scalar_parser` configuration of queries.

# Overview

- Add an `attr_accessor` for `scalar_parser` to `Query`
- Pass this along in `column_value_parsers`
- Fix an issue where the shorthand used in `Query#transform_rows` was incorrect (sorry!)
- Add an example of using `transform_row` and `scalar_parser` to the README.

@fionaochs paired on this with me 🎉 

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary