### PR TITLE
fix: Retry GET against 502, 503 responses

### DIFF
--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -208,7 +208,8 @@ module Trino::Client
             return response
           end
 
-          if response.status != 503  # retry only if 503 Service Unavailable
+          # retry if 502, 503, 504 according to the trino protocol
+          if response.status == 502 || response.status == 503 || response.status == 504
             # deterministic error
             exception! TrinoHttpError.new(response.status, "Trino API error at #{uri} returned #{response.status}: #{response.body}")
           end

--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -209,7 +209,7 @@ module Trino::Client
           end
 
           # retry if 502, 503, 504 according to the trino protocol
-          if response.status == 502 || response.status == 503 || response.status == 504
+          unless [502, 503, 504].include?(response.status)
             # deterministic error
             exception! TrinoHttpError.new(response.status, "Trino API error at #{uri} returned #{response.status}: #{response.body}")
           end


### PR DESCRIPTION
# Purpose

Retry GET against 502, 503 responses.

# Overview

According to the trino client protocol, it should also retry for 502 and 504. (https://github.com/treasure-data/trino-client-ruby/issues/128)

> https://trino.io/docs/current/develop/client-protocol.html#overview-of-query-processing
If the client request returns an HTTP 502, 503, or 504, that means there was an intermittent problem processing request and the client should try again in 50-100 ms. Trino does not generate those codes by itself, but those can be generated by load balancers in front of Trino.

# Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary