### PR TITLE
Make sure sending cancel request in StatementClient.close

### DIFF
--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -262,9 +262,11 @@ module Trino::Client
     end
 
     def close
-      return unless running?
+      return if finished? || query_failed? || client_aborted?
 
-      @state = :client_aborted
+      if running?
+        @state = :client_aborted
+      end
 
       begin
         if uri = @results.next_uri


### PR DESCRIPTION
# Purpose

Make sure sending cancel request in `StatementClient.close()`

# Overview

`StatementClient.close()` sends a cancel request:
https://github.com/treasure-data/trino-client-ruby/blob/55c3bdce35c1b3feca019ba1d0518d6f02b21b8e/lib/trino/client/statement_client.rb#L264-L280

But it doesn't if any errors happen inside the client because `state` is changed to `client_error` in `exception!()`:
https://github.com/treasure-data/trino-client-ruby/blob/55c3bdce35c1b3feca019ba1d0518d6f02b21b8e/lib/trino/client/statement_client.rb#L133-L136

This change will make sure sending a cancel request when `StatementClient.close()` is called unless `state` is `finished`, `query_failed` or `client_abort`.

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary