### PR TITLE
fix: Retry POST against 502, 503 and 504 responses

### DIFF
--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -85,7 +85,7 @@ module Trino::Client
         end
 
         if response
-          if response.status == 200 && !response.body.to_s.empty?
+          if response.status == 200
             @results_headers = response.headers
             @results = decode_model(uri, parse_body(response), @models::QueryResults)
             return

--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -66,20 +66,46 @@ module Trino::Client
 
     def post_query_request!
       uri = "/v1/statement"
-      response = @faraday.post do |req|
-        req.url uri
 
-        req.body = @query
-        init_request(req)
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      attempts = 0
+
+      loop do
+        begin
+          response = @faraday.post do |req|
+            req.url uri
+            req.body = @query
+            init_request(req)
+          end
+        rescue Faraday::TimeoutError, Faraday::ConnectionFailed
+          # temporally error to retry
+          response = nil
+        rescue => e
+          exception! e
+        end
+
+        if response
+          if response.status == 200 && !response.body.to_s.empty?
+            @results_headers = response.headers
+            @results = decode_model(uri, parse_body(response), @models::QueryResults)
+            return
+          end
+          # retry if 502, 503, 504 according to the trino protocol
+          unless [502, 503, 504].include?(response.status)
+            # deterministic error
+            exception! TrinoHttpError.new(response.status, "Trino API error at #{uri} returned #{response.status}: #{response.body}")
+          end
+        end
+
+        raise_if_timeout!
+
+        attempts += 1
+        sleep attempts * 0.1
+
+        break unless (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) < @retry_timeout && !client_aborted?
       end
 
-      # TODO error handling
-      if response.status != 200
-        exception! TrinoHttpError.new(response.status, "Failed to start query: #{response.body} (#{response.status})")
-      end
-
-      @results_headers = response.headers
-      @results = decode_model(uri, parse_body(response), @models::QueryResults)
+      exception! TrinoHttpError.new(408, "Trino API error due to timeout")
     end
 
     private :post_query_request!


### PR DESCRIPTION
# Purpose

Retry POST against 50X responses.

Here's what I'd like to see reviewed
1. Please confirm that it is okay to handle Timeout within the POST function. 
2. I am not familiar with the Ruby language, so there may be some errors. I have written it to follow the same logic as the existing `faraday_get_with_retry` as much as possible. 

# Overview

According to the trino client protocol, it should also retry for POST. 
- https://github.com/treasure-data/trino-client-ruby/issues/128#issuecomment-2531729299

> https://trino.io/docs/current/develop/client-protocol.html#overview-of-query-processing
If the client request returns an HTTP 502, 503, or 504, that means there was an intermittent problem processing request and the client should try again in 50-100 ms. Trino does not generate those codes by itself, but those can be generated by load balancers in front of Trino.

# Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary