### PR TITLE
Tune Ruby versions in CI / Drop ruby 2.7, 3.0 and 3.1 supports

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.2']
+        ruby-version: ['3.2', '3.3', '3.4']
         faraday-version: ['~> 1', '~> 2']
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org/"
+ruby "~> 3.2"
 gemspec
 
 group :development, :test do
-  gem "tiny-presto", "~> 0.0.10"
   gem "faraday", ENV.fetch("FARADAY_VERSION", "~> 2")
+  gem "tiny-presto", "~> 0.0.10"
 end

--- a/trino-client-ruby/trino-client-ruby.gemspec
+++ b/trino-client-ruby/trino-client-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files         = ["lib/trino-client-ruby.rb"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.7.0"
+  gem.required_ruby_version = ">= 3.2.0"
 
   gem.add_dependency "trino-client", Trino::Client::VERSION
 end

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.7.0"
+  gem.required_ruby_version = ">= 3.2.0"
 
   gem.add_dependency "faraday", ">= 1", "< 3"
   gem.add_dependency "faraday-gzip", ">= 1"

--- a/trino-client.gemspec
+++ b/trino-client.gemspec
@@ -22,6 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday-follow_redirects", ">= 0.3"
   gem.add_dependency "msgpack", [">= 1.5.1"]
 
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+    gem.add_dependency("base64")
+  end
+
   gem.add_development_dependency "rake", [">= 0.9.2", "< 14.0"]
   gem.add_development_dependency "rspec", "~> 3.13.0"
   gem.add_development_dependency "webmock", ["~> 3.0"]


### PR DESCRIPTION
# Purpose

Tune Ruby version supports

# Overview
- Drop ruby 2.7 support
- Run tests with ruby 3.3 and 3.4 on Github Actions
- Tune gemspec and Gemfile

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary