### PR TITLE
Close StatementClient when hitting client-side timeout

### DIFF
--- a/lib/trino/client/statement_client.rb
+++ b/lib/trino/client/statement_client.rb
@@ -233,6 +233,7 @@ module Trino::Client
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @started_at
 
         if @query_timeout && elapsed > @query_timeout
+          close
           raise_timeout_error!
         end
 
@@ -240,6 +241,7 @@ module Trino::Client
             elapsed > @plan_timeout
           # @results is not set (even first faraday_get_with_retry isn't called yet) or
           # result from Trino doesn't include result schema. Query planning isn't done yet.
+          close
           raise_timeout_error!
         end
       end


### PR DESCRIPTION
# Purpose

Ensure sending a query cancel request when hitting client-side timeout.

# Overview

`StatementClient.close` sends a query cancel request but it doesn't work after hitting the client-side timeout because the internal state has been changed by `raise_timeout_error!` when `close` is called.

In order to ensure sending a query cancel request, call `close` automatically before throwing the exception when hitting the client-side timeout.

This is a port of https://github.com/trinodb/trino/pull/24446

# Checklist

- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary