### PR TITLE
Add http_debug_logger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ $ bundle exec rake modelgen:latest
 * **http_headers** sets custom HTTP headers. It must be a Hash of string to string.
 * **http_proxy** sets host:port of a HTTP proxy server.
 * **http_debug** enables debug message to STDOUT for each HTTP requests.
+* **http_debug_logger** sets a custom `Logger` instance for HTTP debug logs. Requires **http_debug** to be `true`.
 * **http_open_timeout** sets timeout in seconds to open new HTTP connection.
 * **http_timeout** sets timeout in seconds to read data from a server.
 * **gzip** enables gzip compression.

--- a/lib/trino/client/faraday_client.rb
+++ b/lib/trino/client/faraday_client.rb
@@ -91,7 +91,7 @@ module Trino::Client
       if options[:gzip]
         faraday.request :gzip
       end
-      faraday.response :logger if options[:http_debug]
+      faraday.response :logger, options[:http_debug_logger] if options[:http_debug]
       faraday.adapter Faraday.default_adapter
     end
 

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -358,7 +358,7 @@ describe Trino::Client::StatementClient do
     it "logs to the custom logger" do
       log_output = StringIO.new
       custom_logger = Logger.new(log_output)
-      custom_logger.progname = "trino-test"
+      custom_logger.formatter = proc { |_, _, _, msg| "[CUSTOM] #{msg}\n" }
 
       stub_request(:post, "localhost/v1/statement").
         to_return(body: response_json.to_json)
@@ -366,7 +366,7 @@ describe Trino::Client::StatementClient do
       f = Trino::Client.faraday_client(server: "localhost", http_debug: true, http_debug_logger: custom_logger)
       f.post("/v1/statement", "select 1")
 
-      expect(log_output.string).to include("trino-test")
+      expect(log_output.string).to include("[CUSTOM]")
     end
 
     it "logs to stdout when http_debug_logger is not provided" do

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -354,6 +354,44 @@ describe Trino::Client::StatementClient do
     end
   end
 
+  describe "http_debug_logger" do
+    it "logs to the custom logger" do
+      log_output = StringIO.new
+      custom_logger = Logger.new(log_output)
+      custom_logger.progname = "trino-test"
+
+      stub_request(:post, "localhost/v1/statement").
+        to_return(body: response_json.to_json)
+
+      f = Trino::Client.faraday_client(server: "localhost", http_debug: true, http_debug_logger: custom_logger)
+      f.post("/v1/statement", "select 1")
+
+      expect(log_output.string).to include("trino-test")
+    end
+
+    it "logs to stdout when http_debug_logger is not provided" do
+      stub_request(:post, "localhost/v1/statement").
+        to_return(body: response_json.to_json)
+
+      f = Trino::Client.faraday_client(server: "localhost", http_debug: true)
+
+      expect { f.post("/v1/statement", "select 1") }.to output.to_stdout_from_any_process
+    end
+
+    it "does not log when http_debug is not set" do
+      log_output = StringIO.new
+      custom_logger = Logger.new(log_output)
+
+      stub_request(:post, "localhost/v1/statement").
+        to_return(body: response_json.to_json)
+
+      f = Trino::Client.faraday_client(server: "localhost", http_debug_logger: custom_logger)
+      f.post("/v1/statement", "select 1")
+
+      expect(log_output.string).to be_empty
+    end
+  end
+
   describe "ssl" do
     it "is disabled by default" do
       f = Query.__send__(:faraday_client, {


### PR DESCRIPTION
# Purpose

Enable masking sensitive information (e.g. Authentication headers) in HTTP debug logs by allowing users to inject a custom logger. 

Faraday's `:logger` middleware also supports options (e.g. filter headers), but exposing them would tightly couple this gem's interface to Faraday's internals. As a first step, only custom logger injection is added.

# Overview

- Add `http_debug_logger` option to faraday_client that is passed to Faraday's `:logger` middleware
- Add tests for custom logger, default logger, and no-logger behavior

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
